### PR TITLE
Add default secret key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ HOST_URL='https://www.scribd.com/doc/'
 SQLALCHEMY_DATABASE_URI=postgresql://localhost/recordtrac
 ADMIN_PASSWORD=admin
 AGENCY_NAME='Your agency name'
+SECRET_KEY='change this before deploying to production'


### PR DESCRIPTION
I didn't test this, I just edited it in-browser. But I'm pretty sure this should work. It adds a default `SECRET_KEY` value, so that the app will run after installation, as the instructions indicate.
